### PR TITLE
altered the foreign key for answers table to fix the error

### DIFF
--- a/src/server/migrations/20210502135612_answers_table.js
+++ b/src/server/migrations/20210502135612_answers_table.js
@@ -7,6 +7,7 @@ exports.up = function (knex) {
     table.integer('dataanalyst_points').notNullable();
     table
       .integer('fk_question_id')
+      .unsigned()
       .notNullable()
       .references('id')
       .inTable('questions');


### PR DESCRIPTION
# Description

There was a mismatch in the foreign key for answers table and question table id. That is fixed by adding .unsigned to the key.

Fixes # (issue)

# How to test?

Please provide a short summary how your changes can be tested?

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] This PR is ready to be merged and not breaking any other functionality
