### PR TITLE
typo chage

### DIFF
--- a/src/client/components/sideMenubar/sideMenu.js
+++ b/src/client/components/sideMenubar/sideMenu.js
@@ -31,7 +31,7 @@ function SideMenu({ highLightItem }) {
           <span>Next steps</span>
           <li
             className="side_menu_whiteborder"
-            data-highlighted={highLigtItem === 2}
+            data-highlighted={highLightItem === 2}
           >
             <a href={highLightItem}>
               <img src={elevatorImg} alt="nextImg" />
@@ -45,5 +45,5 @@ function SideMenu({ highLightItem }) {
 }
 export default SideMenu;
 SideMenu.propTypes = {
-  highLigtItem: PropTypes.number.isRequired,
+  highLightItem: PropTypes.number.isRequired,
 };


### PR DESCRIPTION
# Description

Its typo in highlight component missing 'h' in sideMenu.js file .. so changed it after merging a branch.

Fixes # (issue)

# How to test?

Please provide a short summary how your changes can be tested?

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] This PR is ready to be merged and not breaking any other functionality
