### PR TITLE
deleted unnecessary font link

### DIFF
--- a/src/client/components/PageHeaderComponent/PageHeader.styles.css
+++ b/src/client/components/PageHeaderComponent/PageHeader.styles.css
@@ -1,5 +1,3 @@
-@import '../../assets/fonts/fonts.css';
-
 .header h1 {
   font-family: 'Chakra Petch', sans-serif;
   letter-spacing: 7px;


### PR DESCRIPTION
# Description

Deleted unnecessary font link from PageHeader.styles.css because it's linked already on App.js
Fixes # (issue) No issue open for this PR

# How to test?

You can go to App.js file and check that the font is already imported there in line 3

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] This PR is ready to be merged and not breaking any other functionality
