### PR TITLE
Add endpoint to retrieve quiz results

### DIFF
--- a/src/server/api/controllers/quiz-results.controller.js
+++ b/src/server/api/controllers/quiz-results.controller.js
@@ -1,0 +1,35 @@
+const knex = require('../../config/db');
+
+const getQuizResults = async (answerId, userId) => {
+  try {
+    let filteredResults;
+    if (answerId != undefined && userId != undefined) {
+      filteredResults = await knex('quiz_results')
+        .where('fk_answer_id', '=', answerId)
+        .where('fk_user_id', '=', userId)
+        .select('id', 'fk_answer_id', 'fk_user_id', 'created_date');
+    } else if (answerId != undefined) {
+      filteredResults = await knex('quiz_results')
+        .where('fk_answer_id', '=', answerId)
+        .select('id', 'fk_answer_id', 'fk_user_id', 'created_date');
+    } else if (userId != undefined) {
+      filteredResults = await knex('quiz_results')
+        .where('fk_user_id', '=', userId)
+        .select('id', 'fk_answer_id', 'fk_user_id', 'created_date');
+    } else {
+      filteredResults = await knex('quiz_results').select(
+        'id',
+        'fk_answer_id',
+        'fk_user_id',
+        'created_date',
+      );
+    }
+    return filteredResults;
+  } catch (error) {
+    return error.message;
+  }
+};
+
+module.exports = {
+  getQuizResults,
+};

--- a/src/server/api/controllers/quiz-results.controller.js
+++ b/src/server/api/controllers/quiz-results.controller.js
@@ -3,16 +3,16 @@ const knex = require('../../config/db');
 const getQuizResults = async (answerId, userId) => {
   try {
     let filteredResults;
-    if (answerId != undefined && userId != undefined) {
+    if (answerId !== undefined && userId !== undefined) {
       filteredResults = await knex('quiz_results')
         .where('fk_answer_id', '=', answerId)
         .where('fk_user_id', '=', userId)
         .select('id', 'fk_answer_id', 'fk_user_id', 'created_date');
-    } else if (answerId != undefined) {
+    } else if (answerId !== undefined) {
       filteredResults = await knex('quiz_results')
         .where('fk_answer_id', '=', answerId)
         .select('id', 'fk_answer_id', 'fk_user_id', 'created_date');
-    } else if (userId != undefined) {
+    } else if (userId !== undefined) {
       filteredResults = await knex('quiz_results')
         .where('fk_user_id', '=', userId)
         .select('id', 'fk_answer_id', 'fk_user_id', 'created_date');

--- a/src/server/api/routes/api-router.js
+++ b/src/server/api/routes/api-router.js
@@ -5,6 +5,8 @@ const router = express.Router();
 // Router imports
 const modulesRouter = require('./modules.router');
 
+const quizResultsRouter = require('./quiz-results.router');
+
 const swaggerJsDoc = require('swagger-jsdoc');
 const swaggerUi = require('swagger-ui-express');
 
@@ -30,5 +32,7 @@ router.use('/documentation', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 // Application routes
 router.use('/modules', modulesRouter);
+
+router.use('/quiz-results', quizResultsRouter);
 
 module.exports = router;

--- a/src/server/api/routes/quiz-results.router.js
+++ b/src/server/api/routes/quiz-results.router.js
@@ -33,8 +33,8 @@ const quizResultsController = require('../controllers/quiz-results.controller');
  *        description: Unexpected error.
  */
 router.get('/', (req, res, next) => {
-  const answerId = req.query.answerId;
-  const userId = req.query.userId;
+  const [answerId, userId] = [req.query.answerId, req.query.userId];
+
   quizResultsController
     .getQuizResults(answerId, userId)
     .then((result) => res.json(result))

--- a/src/server/api/routes/quiz-results.router.js
+++ b/src/server/api/routes/quiz-results.router.js
@@ -1,0 +1,44 @@
+const express = require('express');
+
+const router = express.Router({ mergeParams: true });
+
+// controllers
+const quizResultsController = require('../controllers/quiz-results.controller');
+
+/**
+ * @swagger
+ * /quiz-results:
+ *  get:
+ *    tags:
+ *    - Quiz Results
+ *    summary: Get quiz results
+ *    description:
+ *      Will return quiz results.
+ *    produces: application/json
+ *    parameters:
+ *      - in: query
+ *        name: answerId
+ *        type: integer
+ *        required: false
+ *        description: The id of the answer.
+ *      - in: query
+ *        name: userId
+ *        type: integer
+ *        required: false
+ *        description: The id of the user.
+ *    responses:
+ *      200:
+ *        description: Successful request
+ *      5XX:
+ *        description: Unexpected error.
+ */
+router.get('/', (req, res, next) => {
+  const answerId = req.query.answerId;
+  const userId = req.query.userId;
+  quizResultsController
+    .getQuizResults(answerId, userId)
+    .then((result) => res.json(result))
+    .catch(next);
+});
+
+module.exports = router;


### PR DESCRIPTION
# Description

Created the GET endpoint for /api/quiz-results. We can filter data in four ways: 
by fk_answer_id column from the table quiz_results
by fk_user_id column
by both
and without queries - this way we will have all the entries

Fixes # 32

# How to test?

You can use Swagger http://localhost:3000/api/documentation/#/Quiz%20Results/get_quiz_results

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] This PR is ready to be merged and not breaking any other functionality
