### PR TITLE
Links functionality to pages of (login) and (create account) for the homepage is added 

### DIFF
--- a/src/client/components/LeftBlueBar/LeftBlueBar.component.js
+++ b/src/client/components/LeftBlueBar/LeftBlueBar.component.js
@@ -10,14 +10,14 @@ function SidebarMenu() {
         <div className="sidebar-title">GuideIT</div>
         <div className="create-account">
           <div>
-            <a href="/">Create account</a>
+            <a href="/registration">Create account</a>
           </div>
           <div className="triangle" />
         </div>
 
         <div className="login">
           <div>
-            <a href="/">Login</a>
+            <a href="/login">Login</a>
           </div>
           <div className="triangle" />
         </div>

--- a/src/client/components/LeftBlueBar/LeftBlueBar.component.js
+++ b/src/client/components/LeftBlueBar/LeftBlueBar.component.js
@@ -2,25 +2,27 @@ import React from 'react';
 import './LeftBlueBar.styles.css';
 import hyfLogo from '../../assets/images/hyf-logo.png';
 import rediLogo from '../../assets/images/redi-logo.png';
+import { BrowserRouter as Router, Link } from 'react-router-dom';
 
 function SidebarMenu() {
   return (
     <div className="sidebar-menu">
       <div className="sidebar-header">
         <div className="sidebar-title">GuideIT</div>
-        <div className="create-account">
-          <div>
-            <a href="/registration">Create account</a>
+        <Router>
+          <div className="create-account">
+            <div>
+              <Link to="/registration">Create account</Link>
+            </div>
+            <div className="triangle" />
           </div>
-          <div className="triangle" />
-        </div>
-
-        <div className="login">
-          <div>
-            <a href="/login">Login</a>
+          <div className="login">
+            <div>
+              <Link to="/login">Login</Link>
+            </div>
+            <div className="triangle" />
           </div>
-          <div className="triangle" />
-        </div>
+        </Router>
       </div>
       <div className="sidebar-footer">
         <img src={hyfLogo} alt="HYF-logo" className="hyf-logo" />

--- a/src/client/components/LeftBlueBar/LeftBlueBar.styles.css
+++ b/src/client/components/LeftBlueBar/LeftBlueBar.styles.css
@@ -28,6 +28,7 @@
   letter-spacing: 0.9px;
   font-size: 22px;
   font-weight: 500;
+  text-decoration: underline;
 }
 
 .create-account a {
@@ -55,6 +56,7 @@
   letter-spacing: 0.9px;
   font-size: 22px;
   font-weight: 500;
+  text-decoration: underline;
 }
 
 .login a {


### PR DESCRIPTION
# Description

Create account and login from the side menu of the home page must direct you to their pages , now the name of the page is added and linked.

Fixes # (#8 )

# How to test?

npm run dev
# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] This PR is ready to be merged and not breaking any other functionality
