### PR TITLE
get by user id api/quiz-results modify

### DIFF
--- a/src/server/api/controllers/quiz-results.controller.js
+++ b/src/server/api/controllers/quiz-results.controller.js
@@ -24,12 +24,15 @@ const getQuizResults = async (answerId, userId) => {
         .where('fk_answer_id', '=', answerId)
         .select('id', 'fk_answer_id', 'fk_user_id', 'created_date');
     } else if (userId !== undefined) {
-      const max = (await knex('questions').count())[0]['count(*)'];
-
+      // get total number of questions from questions table.
+      const numberOfQuestions = (await knex('questions').count())[0][
+        'count(*)'
+      ];
+      // Get latest records with userid from quiz_results upto to numberOfQuestions
       filteredResults = await knex('quiz_results')
         .where('fk_user_id', '=', userId)
         .orderBy('created_date', 'desc')
-        .limit(Number(max));
+        .limit(Number(numberOfQuestions));
     } else {
       filteredResults = await knex('quiz_results').select(
         'id',

--- a/src/server/api/controllers/quiz-results.controller.js
+++ b/src/server/api/controllers/quiz-results.controller.js
@@ -24,9 +24,12 @@ const getQuizResults = async (answerId, userId) => {
         .where('fk_answer_id', '=', answerId)
         .select('id', 'fk_answer_id', 'fk_user_id', 'created_date');
     } else if (userId !== undefined) {
+      const max = (await knex('questions').count())[0]['count(*)'];
+
       filteredResults = await knex('quiz_results')
         .where('fk_user_id', '=', userId)
-        .select('id', 'fk_answer_id', 'fk_user_id', 'created_date');
+        .orderBy('created_date', 'desc')
+        .limit(Number(max));
     } else {
       filteredResults = await knex('quiz_results').select(
         'id',


### PR DESCRIPTION
# Description

I have modify the api\controllers\quiz-results.controller.js . Now  it returns latest records from quiz_results with given user id up to the total number of questions in questions table. 
Fixes # (issue) backend part of issue
#136 

# How to test?
try to get results with userId from Swagger at following address it will return latest records up to max number of questions in questions table. 
http://localhost:5000/api/documentation/#/Quiz%20Results/get_quiz_results

# Checklist

- [x ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] This PR is ready to be merged and not breaking any other functionality
