### PR TITLE
fixed buttons at home page not showing at some screen resolutions

### DIFF
--- a/src/client/containers/QuizPage/QuizPage.styles.css
+++ b/src/client/containers/QuizPage/QuizPage.styles.css
@@ -54,9 +54,6 @@
   justify-content: space-around;
   align-items: center;
   text-align: center;
-}
-
-.buttons.big {
   min-width: 150px;
   padding: 0.2em 2em;
   margin-top: 120px;


### PR DESCRIPTION
# Description
Buttons at home page are not showing at some screen resolutions. To resolve it I have 
removed .button.big and moved it style under .button-page  in quizpage.style.


Fixes # (issue) there is no open issue for it.

# How to test?
Run npm run dev and inspect the app at different screen resolutions. 



# Checklist

- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] This PR is ready to be merged and not breaking any other functionality
