### PR TITLE
fixed quiz page link 

### DIFF
--- a/src/client/containers/Home/Home.container.js
+++ b/src/client/containers/Home/Home.container.js
@@ -52,7 +52,7 @@ export const Home = () => {
               size="big"
               isMono={true}
               color="orange"
-              onClick={() => handleClick('/career')}
+              onClick={() => handleClick('/quiz')}
             />
           </div>
 


### PR DESCRIPTION
# Description

take the career quiz button was redirecting to career page , now I have fix it so, that it will redirect to quiz page. 

Fixes # (issue) there is now open issue for this.

# How to test?

please run npm run dev and at home page click "take the career quiz" button it should redirect to quiz page.

# Checklist

- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] This PR is ready to be merged and not breaking any other functionality
