### PR TITLE
added elevator component, without pagination(for now)

### DIFF
--- a/src/client/components/Elevator/Elevator.component.js
+++ b/src/client/components/Elevator/Elevator.component.js
@@ -52,22 +52,22 @@ const ElevatorLevel = ({
         className="elevator-content"
         dangerouslySetInnerHTML={{ __html: content }}
       />
-      {floor > 0 && floor <= 5 ? (
+      {floor >= 0 && floor < 5 ? (
         <img
           src={UpArrow}
-          alt="go to previous"
-          onClick={onClickPrev}
+          alt="go to next"
+          onClick={onClickNext}
           aria-hidden="true"
           className="elevator-arrow elevator-up"
         />
       ) : (
         <div />
       )}
-      {floor >= 0 && floor < 5 ? (
+      {floor > 0 && floor <= 5 ? (
         <img
           src={DownArrow}
-          alt="go to next"
-          onClick={onClickNext}
+          alt="go to previous"
+          onClick={onClickPrev}
           aria-hidden="true"
           className="elevator-arrow elevator-down"
         />

--- a/src/client/components/Elevator/Elevator.component.js
+++ b/src/client/components/Elevator/Elevator.component.js
@@ -117,3 +117,11 @@ export default Elevator;
 Elevator.propTypes = {
   level: PropTypes.number.isRequired,
 };
+
+ElevatorLevel.propTypes = {
+  header: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+  floor: PropTypes.number.isRequired,
+  onClickPrev: PropTypes.func.isRequired,
+  onClickNext: PropTypes.func.isRequired,
+};

--- a/src/client/components/Elevator/Elevator.component.js
+++ b/src/client/components/Elevator/Elevator.component.js
@@ -100,8 +100,9 @@ function Elevator({ level }) {
         .filter((item, index) => {
           return index === floor;
         })
-        .map((item) => (
+        .map((item, index) => (
           <ElevatorLevel
+            key={index}
             header={item.header}
             content={item.content}
             floor={floor}

--- a/src/client/components/Elevator/Elevator.component.js
+++ b/src/client/components/Elevator/Elevator.component.js
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import './Elevator.styles.css';
+import UpArrow from '../../assets/images/up_arrow.png';
+import DownArrow from '../../assets/images/down_arrow.png';
+// import Pagination from '../Pagination/Pagination.component';
+
+const elevatorSpeechArray = [
+  {
+    header: 'PRESENTING YOURSELF',
+    content:
+      '<p>This speech is all about YOU: who you are, what you do, and what you want to do!</p> <h3>Steps:</h3> <ol><li>Start by introducing yourself</li><li>Provide a summary of what you do</li><li>Explain what you want</li><li>Finish with a call to action</li></ol>',
+  },
+  {
+    header: 'PRESENTING YOURSELF',
+    content:
+      "<h3>What to say?</h3><ul><li>Your elevator speech should be brief (1-minute speech).</li><li>Share your skills! Explain who you are and what qualifications and skills you have.</li><li>This is your chance to brag a bit(but not too much!).</li><li>Be positive and flexible.</li><li>Don't start with the stuff you'd rather not be doing.</li></ul>",
+  },
+  {
+    header: 'PRESENTING YOURSELF',
+    content:
+      '<h3>Craft your pitch</h3><p><span></span>Hello, my name is ____________ and I am completing a ____________ degree in ____________ at XYZ school.</p><p>I am interested in a career in (or position as a) ____________ in the ____________ field (industry).</p><p>I have involved (during college or previous job) in ____________.</p><p>And developed skills in ____________. I have also had an internship position (employment) as a ____________ with ____________ and discovered that I really enjoy ____________.</p><p>Could you tell me more about ____________?</p>',
+  },
+  {
+    header: 'PRESENTING YOURSELF',
+    content:
+      '<h5>Avoid:</h5><p>Speaking too fast.</p><p>Rambling (It&lsquo;s so important to practice your elevator speech.)</p><p>Don&lsquo;t frown, or speak in a monotone way. Here&lsquo;s one of the downsides to rehearsing: it can leave you more focused on remembering the exact words you want to use, and less on how you&lsquo;re carrying yourself. Keep your energy level high, confident, and enthusiastic.</p>',
+  },
+  {
+    header: 'EXAMPLES',
+    content:
+      '<p>I recently graduated from college with a degree in communications. I worked on the college newspaper as a reporter, and eventually, as the editor of the arts section. I&lsquo;m looking for a job that will put my skills as a journalist to work.</p><p>I create illustrations for websites and brands. My passion is coming up with creative ways to express a message, and drawing illustrations that people share on social media.</p>',
+  },
+  {
+    header: 'KEY TAKEAWAYS',
+    content:
+      '<h4>Keep it short and sweet:</h4><p>Your elevator speech is a sales pitch. Be sure you can deliver your message in 60 seconds or less.</p><h4>Focus on the essentials:</h4><p>Say who you are, what you do, and what you want to achieve.</p><h4>Be positive:</h4><p>Your time is limited. Focus on what you want to do, not what you do&lsquo;t want to do. Be upbeat and flexible.</p><h4>Practice, practice, practice:</h4><p>Deliver your speech to a friend or record it, so that you can be sure that your message is clear.</p>',
+  },
+];
+
+const ElevatorLevel = ({
+  header,
+  content,
+  floor,
+  onClickPrev,
+  onClickNext,
+}) => {
+  return (
+    <div className="elevator-level">
+      <h3 className="elevator-heading">{header}</h3>
+      <div
+        className="elevator-content"
+        dangerouslySetInnerHTML={{ __html: content }}
+      />
+      {floor > 0 && floor <= 5 ? (
+        <img
+          src={UpArrow}
+          alt="go to previous"
+          onClick={onClickPrev}
+          aria-hidden="true"
+          className="elevator-arrow elevator-up"
+        />
+      ) : (
+        <div />
+      )}
+      {floor >= 0 && floor < 5 ? (
+        <img
+          src={DownArrow}
+          alt="go to next"
+          onClick={onClickNext}
+          aria-hidden="true"
+          className="elevator-arrow elevator-down"
+        />
+      ) : (
+        <div />
+      )}
+    </div>
+  );
+};
+
+function Elevator({ level }) {
+  const [floor, setFloor] = useState(level);
+  const handleClickPrev = (e) => {
+    e.preventDefault();
+    setFloor((prev) => prev - 1);
+  };
+  const handleClickNext = (e) => {
+    e.preventDefault();
+    setFloor((prev) => prev + 1);
+  };
+  // will add this after pagination component is merged
+  // const handleClickPagination = (item) => {
+  //   setFloor(item);
+  // };
+  return (
+    <div className="elevator-component">
+      {/* will add this after pagination component is merged */}
+      {/* <Pagination floor={floor} handleClickPagination={handleClickPagination} /> */}
+      {elevatorSpeechArray
+        .filter((item, index) => {
+          return index === floor;
+        })
+        .map((item) => (
+          <ElevatorLevel
+            header={item.header}
+            content={item.content}
+            floor={floor}
+            onClickPrev={handleClickPrev}
+            onClickNext={handleClickNext}
+          />
+        ))}
+    </div>
+  );
+}
+
+export default Elevator;
+
+Elevator.propTypes = {
+  level: PropTypes.number.isRequired,
+};

--- a/src/client/components/Elevator/Elevator.component.js
+++ b/src/client/components/Elevator/Elevator.component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import './Elevator.styles.css';
 import UpArrow from '../../assets/images/up_arrow.png';
 import DownArrow from '../../assets/images/down_arrow.png';
-// import Pagination from '../Pagination/Pagination.component';
+import Pagination from '../Pagination/Pagination.component';
 
 const elevatorSpeechArray = [
   {
@@ -88,14 +88,12 @@ function Elevator({ level }) {
     e.preventDefault();
     setFloor((prev) => prev + 1);
   };
-  // will add this after pagination component is merged
-  // const handleClickPagination = (item) => {
-  //   setFloor(item);
-  // };
+  const handleClickPagination = (item) => {
+    setFloor(item);
+  };
   return (
     <div className="elevator-component">
-      {/* will add this after pagination component is merged */}
-      {/* <Pagination floor={floor} handleClickPagination={handleClickPagination} /> */}
+      <Pagination floor={floor} handleClickPagination={handleClickPagination} />
       {elevatorSpeechArray
         .filter((item, index) => {
           return index === floor;

--- a/src/client/components/Elevator/Elevator.stories.js
+++ b/src/client/components/Elevator/Elevator.stories.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import Elevator from './Elevator.component';
+import PropTypes from 'prop-types';
+
+export default {
+  title: 'Components/Elevator',
+  component: Elevator,
+  argTypes: {
+    level: {
+      control: {
+        type: 'select',
+        options: [0, 1, 2, 3, 4, 5],
+      },
+    },
+  },
+};
+
+const Template = ({ level }) => <Elevator level={level} />;
+
+export const elevator = Template.bind({});
+elevator.args = {
+  level: 0,
+};
+
+Template.propTypes = {
+  level: PropTypes.number.isRequired,
+};

--- a/src/client/components/Elevator/Elevator.styles.css
+++ b/src/client/components/Elevator/Elevator.styles.css
@@ -1,0 +1,144 @@
+.elevator-component {
+  width: 55%;
+  height: 42rem;
+  margin-left: 22%;
+  background-color: #d0dddc;
+  text-align: left;
+  font-family: 'Roboto Mono', monospace;
+  position: relative;
+  margin-top: 10%;
+  padding-top: 2.5%;
+  margin-bottom: 0;
+}
+
+.elevator-level {
+  width: 75%;
+  height: 35rem;
+  margin: auto;
+  margin-top: 3%;
+  background-color: #f0f0f0;
+  padding: 8%;
+}
+
+.elevator-heading {
+  text-align: center;
+  color: #4a9f9c;
+  margin-bottom: 8%;
+  text-transform: uppercase;
+}
+
+.elevator-content h3 {
+  color: #4a9f9c;
+  font-size: 1rem;
+}
+
+.elevator-content h4 {
+  text-transform: capitalize;
+  font-weight: bold;
+  font-size: 1rem;
+  margin-bottom: -3%;
+}
+
+.elevator-content h5 {
+  color: #4a9f9c;
+  font-size: 1rem;
+  margin-bottom: -3%;
+  text-transform: uppercase;
+}
+
+.elevator-content ol li {
+  text-align: left;
+  margin: 0 auto;
+}
+
+.elevator-content ul {
+  list-style: none;
+  margin-top: 0;
+}
+
+.elevator-content ul li::before {
+  content: '-';
+  display: inline-block;
+}
+
+.elevator-content ul li {
+  text-align: left;
+  margin: 0 auto 3% -13%;
+}
+
+.elevator-content p span {
+  margin-left: 15%;
+}
+
+.elevator-arrow {
+  background-color: transparent;
+  cursor: pointer;
+  position: absolute;
+  right: 2rem;
+  width: 4%;
+}
+
+.elevator-up {
+  top: 21rem;
+}
+
+.elevator-down {
+  top: 25rem;
+}
+
+/* taking resolution into consideration only for 1024x768 to 1920x1080 screens */
+@media (min-width: 1024px) and (max-width: 1150px) {
+  .elevator-component {
+    height: 45rem;
+  }
+
+  .elevator-level {
+    height: 39rem;
+  }
+
+  .elevator-arrow {
+    right: 1.3rem;
+  }
+}
+
+@media (min-width: 1151px) and (max-width: 1300px) {
+  .elevator-component {
+    height: 42rem;
+  }
+
+  .elevator-level {
+    height: 36rem;
+  }
+
+  .elevator-arrow {
+    right: 1.4rem;
+  }
+}
+
+@media (min-width: 1600px) and (max-width: 1750px) {
+  .elevator-component {
+    height: 42rem;
+  }
+
+  .elevator-level {
+    height: 34.5rem;
+  }
+
+  .elevator-arrow {
+    right: 2.1rem;
+  }
+}
+
+@media (min-width: 1751px) and (max-width: 1920px) {
+  .elevator-component {
+    height: 42.5rem;
+  }
+
+  .elevator-level {
+    height: 34.5rem;
+  }
+
+  .elevator-arrow {
+    right: 2.7rem;
+  }
+}


### PR DESCRIPTION
# Description

This is the elevator component inside elevator-pitch page that renders single elevator page from 0 to 5. Can be controlled by up and down arrows and also by passing the current level props from its parent or storybook.

Fixes #105 

# How to test?

Elevator component can be added in App.js route './elevator-pitch' and can be checked passing a level from 0 to 5.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] This PR is ready to be merged and not breaking any other functionality
