### PR TITLE
Fixed test

### DIFF
--- a/src/client/containers/Home/Home.test.js
+++ b/src/client/containers/Home/Home.test.js
@@ -2,11 +2,18 @@ import '@testing-library/jest-dom/extend-expect';
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 import { Home } from './Home.container';
 
 test('Home section has correct classname', () => {
-  const title = 'home';
+  const title = 'home-container';
 
-  expect(render(<Home />).container.firstChild).toHaveClass(title);
+  expect(
+    render(
+      <Router>
+        <Home />
+      </Router>,
+    ).container.firstChild,
+  ).toHaveClass(title);
 });


### PR DESCRIPTION
# Description

The test was breaking the build. The test was testing if the first child in Home had a classname of "home". But the first child's class name is "home-container". So I updated the test page.

Fixes # no issue for this PR.

# How to test?

Open the fix-text branch and run "npm run test". Should pass  now.

# Checklist

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] This PR is ready to be merged and not breaking any other functionality
