### PR TITLE
question-image-url-from-other-server

### DIFF
--- a/src/server/seeds/development/01_questions.js
+++ b/src/server/seeds/development/01_questions.js
@@ -11,8 +11,7 @@ exports.seed = function (knex) {
           id: 1,
           question:
             'When visiting a website, what is that you are most interested in?',
-          image_url:
-            'src/client/assets/images/questionBackgrounds/question1background.png',
+          image_url: 'https://i.ibb.co/tqp7Qm4/question1background.png',
           is_agreement_question: false,
           created_date: '2020-05-10 00:00:00',
         },
@@ -20,8 +19,7 @@ exports.seed = function (knex) {
           id: 2,
           question:
             'I can easily notice changes around me including people, culture, trends, etc.',
-          image_url:
-            'src/client/assets/images/questionBackgrounds/question2background.png',
+          image_url: 'https://i.ibb.co/TW1gH2w/question2background.png',
           is_agreement_question: true,
           created_date: '2020-05-10 00:00:00',
         },
@@ -29,8 +27,7 @@ exports.seed = function (knex) {
           id: 3,
           question:
             'When I have a list of tasks to do, I prefer to multitask rather than focusing on singular tasks one at a time',
-          image_url:
-            'src/client/assets/images/questionBackgrounds/question3background.png',
+          image_url: 'https://i.ibb.co/4ZHy7rH/question3background.png',
           is_agreement_question: true,
           created_date: '2020-05-10 00:00:00',
         },
@@ -38,16 +35,14 @@ exports.seed = function (knex) {
           id: 4,
           question:
             'I can easily understand what someone else is going through',
-          image_url:
-            'src/client/assets/images/questionBackgrounds/question4background.png',
+          image_url: 'https://i.ibb.co/KsgqSS2/question4background.png',
           is_agreement_question: true,
           created_date: '2020-05-10 00:00:00',
         },
         {
           id: 5,
           question: 'I work well under pressure',
-          image_url:
-            'src/client/assets/images/questionBackgrounds/question5background.png',
+          image_url: 'https://i.ibb.co/zxyzkz5/question5background.png',
           is_agreement_question: true,
           created_date: '2020-05-10 00:00:00',
         },


### PR DESCRIPTION
# Description
questions background images was displaying while we run app on local machine but they were not displaying when we access our app from heroku server ,So I have uploaded images at an other server and provided the link in questions seeding.
 
Fixes # (issue)

# How to test?
after updating latest seeding in database. please run
npm run dev
# Checklist

- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] This PR is ready to be merged and not breaking any other functionality
