### PR TITLE
CSS changes to quiz-page container

### DIFF
--- a/src/client/components/QuizAnswers/QuizAnswers.component.js
+++ b/src/client/components/QuizAnswers/QuizAnswers.component.js
@@ -10,7 +10,7 @@ function QuizAnswers({
 }) {
   return (
     <form>
-      <div className={isAgreementQuestion === 1 ? 'inline' : ''}>
+      <div className={isAgreementQuestion === 1 ? 'inline answers' : 'answers'}>
         {answers.map((answer, index) => {
           const isMiddle = index !== 0 && index !== answers.length - 1;
           return (

--- a/src/client/components/QuizAnswers/QuizAnswers.styles.css
+++ b/src/client/components/QuizAnswers/QuizAnswers.styles.css
@@ -13,10 +13,21 @@
   flex-direction: row-reverse;
 }
 
+.answers {
+  padding-top: 20px;
+  margin-top: 50px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6em;
+}
+
 /* Agreement type questions are aligned inline */
 .inline {
-  display: flex;
-  gap: 0.6em;
+  margin-right: calc(10vw + 49px);
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  flex-direction: row;
 }
 
 /* Neutral radio button is smaller then Agree/Disagree buttons */

--- a/src/client/containers/QuizPage/QuizPage.styles.css
+++ b/src/client/containers/QuizPage/QuizPage.styles.css
@@ -86,16 +86,6 @@
   font-size: 1.8em;
 }
 
-.inline {
-  padding-top: 20px;
-  width: 50%;
-  margin-top: 50px;
-  margin-left: 18%;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-}
-
 .progress-status {
   background-color: #db643d;
   border: 1px solid #db643d;


### PR DESCRIPTION
# Description

I centred the agreement question answers. I added white space to the non-agreement question answers, and I looked at the different is size between the image and the placeholder background (in case an image doesn't load, this allows the question to be visible). I didn't solve that last problem here. That will have to be a separate PR.

Fixes # 

# How to test?

Open quiz page and have a look.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] This PR is ready to be merged and not breaking any other functionality
